### PR TITLE
fix: enable strict TypeScript on API

### DIFF
--- a/apps/api/src/auth/dto/auth-response.dto.ts
+++ b/apps/api/src/auth/dto/auth-response.dto.ts
@@ -5,15 +5,15 @@ import { Role } from '../../../generated/prisma';
  * Excludes sensitive data like password
  */
 export class UserResponse {
-  id: string;
-  email: string;
-  role: Role;
+  id!: string;
+  email!: string;
+  role!: Role;
 }
 
 /**
  * Response returned from signup and login endpoints
  */
 export class AuthResponse {
-  access_token: string;
-  user: UserResponse;
+  access_token!: string;
+  user!: UserResponse;
 }

--- a/apps/api/src/auth/dto/login.dto.ts
+++ b/apps/api/src/auth/dto/login.dto.ts
@@ -2,9 +2,9 @@ import { IsEmail, IsNotEmpty, MinLength } from 'class-validator';
 
 export class LoginDto {
   @IsEmail()
-  email: string;
+  email!: string;
 
   @IsNotEmpty()
   @MinLength(8)
-  password: string;
+  password!: string;
 }

--- a/apps/api/src/auth/dto/register.dto.ts
+++ b/apps/api/src/auth/dto/register.dto.ts
@@ -2,9 +2,9 @@ import { IsEmail, IsString, MinLength } from 'class-validator';
 
 export class RegisterDto {
   @IsEmail()
-  email: string;
+  email!: string;
 
   @IsString()
   @MinLength(8)
-  password: string;
+  password!: string;
 }

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -16,10 +16,11 @@
     "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
-    "strictNullChecks": true,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "noImplicitAny": false,
-    "strictBindCallApply": false,
-    "noFallthroughCasesInSwitch": false
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
   }
 }


### PR DESCRIPTION
## Summary
- Enable `strict: true` on `apps/api/tsconfig.json` to match web and shared packages
- Add `noUncheckedIndexedAccess`, `noImplicitOverride`, `noImplicitReturns`, `noFallthroughCasesInSwitch`
- Fix `strictPropertyInitialization` errors in NestJS DTOs by adding `!` definite assignment assertions

## Why
NestJS DTOs are populated by `class-transformer` at runtime, not constructors — TypeScript can't see this, so `!` is the correct fix (not adding constructors or default values).

## Test plan
- [ ] `npx tsc --noEmit` produces 0 errors
- [ ] All 28 unit tests pass (`cd apps/api && npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved TypeScript type strictness to enhance code reliability and prevent potential runtime errors in authentication modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->