### PR TITLE
fix: enforce password length, require loginType, move role check to service

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, ForbiddenException, Get, Post, Res, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Post, Res, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import type { Response } from 'express';
 import { AuthService } from './auth.service';
@@ -39,14 +39,6 @@ export class AuthController {
   @Post('login')
   async login(@Body() dto: LoginDto, @Res({ passthrough: true }) res: Response) {
     const { access_token, user } = await this.authService.login(dto);
-
-    if (dto.loginType === 'admin' && user.role !== 'ADMIN') {
-      throw new ForbiddenException('このページは管理者専用です');
-    }
-    if (dto.loginType === 'user' && user.role !== 'USER') {
-      throw new ForbiddenException('管理者は /admin/login からログインしてください');
-    }
-
     res.cookie('access_token', access_token, COOKIE_OPTIONS);
     return { user };
   }

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { ConflictException, Injectable, UnauthorizedException } from '@nestjs/common';
+import { ConflictException, ForbiddenException, Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
 import { Role } from '../../generated/prisma';
@@ -55,6 +55,13 @@ export class AuthService {
     const isPasswordValid = await bcrypt.compare(dto.password, user.password);
     if (!isPasswordValid) {
       throw new UnauthorizedException('Invalid credentials');
+    }
+
+    if (dto.loginType === 'admin' && user.role !== 'ADMIN') {
+      throw new ForbiddenException('このページは管理者専用です');
+    }
+    if (dto.loginType === 'user' && user.role !== 'USER') {
+      throw new ForbiddenException('管理者は /admin/login からログインしてください');
     }
 
     // Generate JWT

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,4 +1,9 @@
-import { ConflictException, ForbiddenException, Injectable, UnauthorizedException } from '@nestjs/common';
+import {
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
 import { Role } from '../../generated/prisma';

--- a/packages/shared/src/schemas/auth.schema.ts
+++ b/packages/shared/src/schemas/auth.schema.ts
@@ -1,14 +1,16 @@
 import { z } from 'zod';
 
+export const MIN_PASSWORD_LENGTH = 8;
+
 export const registerSchema = z.object({
   email: z.email(),
-  password: z.string().min(8),
+  password: z.string().min(MIN_PASSWORD_LENGTH),
 });
 
 export const loginSchema = z.object({
   email: z.email(),
-  password: z.string().min(1),
-  loginType: z.enum(['user', 'admin']).optional(),
+  password: z.string().min(MIN_PASSWORD_LENGTH),
+  loginType: z.enum(['user', 'admin']),
 });
 
 export const authResponseSchema = z.object({


### PR DESCRIPTION
Closes #71
Closes #72
Closes #73

## Summary

- Add `MIN_PASSWORD_LENGTH = 8` constant to shared schema — used by both `registerSchema` and `loginSchema` for consistency
- `loginSchema.password` changed from `min(1)` to `min(MIN_PASSWORD_LENGTH)`
- `loginType` changed from `.optional()` to required — direct API calls without it are now rejected at the schema level
- `loginType` role check moved from `AuthController.login()` into `AuthService.login()` — business logic belongs in the service, not the controller

## Test plan

- [ ] Login with correct role succeeds
- [ ] Login with wrong role returns 403
- [ ] Login without `loginType` returns 400
- [ ] Login with password shorter than 8 chars returns 400
- [ ] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced authentication security by enforcing role-based access validation during login to prevent unauthorized portal access.

* **Refactor**
  * Standardized password length validation across all authentication flows using a centralized constant.
  * Made login type field mandatory to ensure users explicitly specify their intended authentication pathway.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->